### PR TITLE
Fix grammar: 'projects handles' to 'project handles'

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,7 +93,7 @@ function isSequencerActive() internal view returns (bool) {
 }
 ```
 
-💡 Check if the projects handles the scenarios where a sequencer is down on optimistic rollup protocols.
+💡 Check if the project handles the scenarios where a sequencer is down on optimistic rollup protocols.
 
 📝 [1](https://github.com/sherlock-audit/2023-02-bond-judging/issues/1) [2](https://github.com/sherlock-audit/2023-01-sentiment-judging/issues/16) [3](https://github.com/sherlock-audit/2022-11-sentiment-judging/issues/3) [4](https://github.com/sherlock-audit/2023-04-jojo-judging/issues/101) [5](https://github.com/code-423n4/2022-09-y2k-finance-findings/issues/278)
 


### PR DESCRIPTION
## Summary
- Fixed subject-verb agreement error in the L2 Sequencer Uptime Feeds section
- Changed "Check if the projects handles" to "Check if the project handles"

## Test plan
- [x] Verified the grammar correction is accurate