### PR TITLE
Fix broken L1BLOCKNUMBER markdown link

### DIFF
--- a/README.md
+++ b/README.md
@@ -121,7 +121,7 @@ As contracts may have different addresses on different chains, the token order c
 
 Some chains implement opcodes with some modification compared to Ethereum, or are not supported.
 
-Optimism for example, [has a different implementation](https://community.optimism.io/docs/developers/build/differences/#modified-opcodes) of opcodes like `block.coinbase`, `block.difficulty`, `block.basefee`. `tx.origin` may also behave different if the it is an L1 => L2 transaction. It also implements some new opcode [L1BLOCKNUMBER](Chains may also implement new opcodes).
+Optimism for example, [has a different implementation](https://community.optimism.io/docs/developers/build/differences/#modified-opcodes) of opcodes like `block.coinbase`, `block.difficulty`, `block.basefee`. `tx.origin` may also behave different if the it is an L1 => L2 transaction. It also implements some new opcodes like `L1BLOCKNUMBER`.
 
 Arbitrum also [has some differences](https://developer.arbitrum.io/solidity-support) in some operations/opcodes like: `blockhash(x)`, `block.coinbase`, `block.difficulty`, `block.number`. `msg.sender` may also behave different for L1 => L2 "retryable ticket" transactions.
 


### PR DESCRIPTION
## Summary
- Fixed broken markdown link in the Modified Opcodes section
- The original text had `[L1BLOCKNUMBER](Chains may also implement new opcodes)` which is malformed (the URL was just descriptive text)
- Changed to properly formatted inline code reference

## Test plan
- [x] Verified the markdown renders correctly