### PR TITLE
Fix incorrect anchor link in Table of Contents

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ Take the observations in this repository as a guideline and kickstarter to your 
   - [Support for the push0 opcode](#support-for-the-push0-opcode)
   - [Address Aliasing - tx.origin / msg.sender](#address-aliasing---txorigin--msgsender)
   - [tx.origin == msg.sender](#txorigin--msgsender)
-  - [transfer, send and fixed gas operations](#txorigin--msgsender)
+  - [transfer, send and fixed gas operations](#transfer-send-and-fixed-gas-operations)
   - [Gas fees](#gas-fees)
   - [Frontrunning](#frontrunning)
   - [Signature replay](#signature-replay)


### PR DESCRIPTION
## Summary
- Fixed incorrect anchor link for "transfer, send and fixed gas operations" in the Table of Contents
- The link was pointing to `#txorigin--msgsender` (wrong section)
- Now correctly points to `#transfer-send-and-fixed-gas-operations`

## Test plan
- [x] Verified the anchor link now navigates to the correct section