### PR TITLE
Fix TOC entry to match section title 'Signature replay across chains'

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ Take the observations in this repository as a guideline and kickstarter to your 
   - [transfer, send and fixed gas operations](#txorigin--msgsender)
   - [Gas fees](#gas-fees)
   - [Frontrunning](#frontrunning)
-  - [Signature replay](#signature-replay)
+  - [Signature replay across chains](#signature-replay-across-chains)
   - [Hardcoded Contract Addresses](#hardcoded-contract-addresses)
   - [ERC20 decimals](#erc20-decimals)
   - [Contracts Interface](#contracts-interface)


### PR DESCRIPTION
## Summary
- Updated TOC entry from "Signature replay" to "Signature replay across chains"
- Now matches the actual section heading and anchor link
- The old link `#signature-replay` was broken; new link `#signature-replay-across-chains` works correctly

## Test plan
- [x] Verified the anchor link navigates to the correct section