### PR TITLE
Fix grammar in Precompiles section

### DIFF
--- a/README.md
+++ b/README.md
@@ -305,7 +305,7 @@ That enabled the possibility of a re-entrancy attack that was exploited and ulti
 
 ### Precompiles
 
-Chains have precompiled contracts on different addresses like [Arbitrum](https://developer.arbitrum.io/arbos/precompiles) or [Optimism](https://github.com/ethereum-optimism/optimism/blob/develop/specs/predeploys.md). Care has to be taken if some is used that is not available, works differently or is on a different address.
+Chains have precompiled contracts on different addresses like [Arbitrum](https://developer.arbitrum.io/arbos/precompiles) or [Optimism](https://github.com/ethereum-optimism/optimism/blob/develop/specs/predeploys.md). Care has to be taken if one is used that is not available, works differently, or is on a different address.
 
 💡 Double-check the use of precompiled contracts, their addresses, and their compatibility
 


### PR DESCRIPTION
## Summary
- Fixed "if some is used" to "if one is used" in the Precompiles section
- Added missing Oxford comma before "or is on a different address"
- "One" is the correct pronoun when referring to a singular item from a group

## Test plan
- [x] Verified the grammar corrections are accurate